### PR TITLE
Generate docs

### DIFF
--- a/docs/.pages
+++ b/docs/.pages
@@ -1,0 +1,4 @@
+title: API Reference
+nav:
+    - Overview: README.md
+    - ...

--- a/docs/README.md
+++ b/docs/README.md
@@ -1,0 +1,20 @@
+<!-- markdownlint-disable -->
+
+# API Overview
+
+## Modules
+
+- No modules
+
+## Classes
+
+- No classes
+
+## Functions
+
+- No functions
+
+
+---
+
+_This file was automatically generated via [lazydocs](https://github.com/ml-tooling/lazydocs)._

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,3 +6,4 @@ pytest-cov
 mypy
 pytest-mypy-plugins
 pytest-asyncio
+lazydocs


### PR DESCRIPTION
Wasn't able to generate docs with Python 3.12 because lazydocs is broken https://github.com/ml-tooling/lazydocs/issues/69

```python
Failed to generate docs for module maybe: AttributeError("'FileFinder' object has no attribute 'find_module'")
```

...and I'm too lazy to setup Python 3.11 right now.

I'll revisit this in future, hopefully lazydocs is fixed for 3.12 by then.