### PR TITLE
Full test coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
           cache-dependency-path: requirements-dev.txt
 
       - name: Install dev dependencies
-        run: pip install --root-user-action=ignore --requirement requirements-dev.txt
+        run: pip install --root-user-action=ignore --upgrade pip --requirement requirements-dev.txt
 
       # Install library
       - name: Install maybe

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@ PYTHON_PRE_310 := $(shell python -c "import sys; print(sys.version_info < (3, 10
 
 install: phony
 	@echo Installing dependencies...
-	pip install --require-virtualenv -r requirements-dev.txt
-	pip install --require-virtualenv -e .
+	python -m pip install --require-virtualenv -r requirements-dev.txt
+	python -m pip install --require-virtualenv -e .
 
 lint: phony lint-flake lint-mypy
 

--- a/src/maybe/maybe.py
+++ b/src/maybe/maybe.py
@@ -13,9 +13,9 @@ from typing import (
     Union,
 )
 
-if sys.version_info >= (3, 10):
+if sys.version_info >= (3, 10):  # pragma: no cover
     from typing import ParamSpec, TypeAlias, TypeGuard
-else:
+else:  # pragma: no cover
     from typing_extensions import ParamSpec, TypeAlias, TypeGuard
 
 

--- a/tests/test_maybe.py
+++ b/tests/test_maybe.py
@@ -4,7 +4,7 @@ from typing import Callable
 
 import pytest
 
-from maybe import Some, SomeNothing, Maybe, Nothing, UnwrapError
+from maybe import Some, SomeNothing, Maybe, Nothing, UnwrapError, is_nothing, is_some
 
 
 def test_some_factories() -> None:
@@ -21,6 +21,7 @@ def test_nothing_factory() -> None:
 def test_eq() -> None:
     assert Some(1) == Some(1)
     assert Nothing() == Nothing()
+    assert not (Nothing() != Nothing())
     assert Some(1) != Nothing()
     assert Some(1) != Some(2)
     assert not (Some(1) != Some(1))
@@ -58,6 +59,14 @@ def test_some() -> None:
     assert res.is_some() is True
     assert res.is_nothing() is False
     assert res.some_value == 'haha'
+
+
+def test_some_guard() -> None:
+    assert is_some(Some(1))
+
+
+def test_nothing_guard() -> None:
+    assert is_nothing(Nothing())
 
 
 def test_nothing() -> None:
@@ -185,7 +194,7 @@ def test_slots() -> None:
 
 
 def sq(i: int) -> Maybe[int]:
-    return Some(i * i)
+    return Some(i**2)
 
 
 def to_nothing(_: int) -> Maybe[int]:

--- a/tests/type-checking/test_maybe.yml
+++ b/tests/type-checking/test_maybe.yml
@@ -92,7 +92,7 @@
     some = personalized_greeting.some()
     reveal_type(some) # N: Revealed type is "Union[builtins.str, None]"
 
-- case: map_maybe
+- case: typeguard
   disable_cache: false
   main: |
     from maybe import Maybe, Some, Nothing, is_some, is_nothing


### PR DESCRIPTION
Increase test coverage to 100%, plus a bit of further tidying:

- Use `python -m pip` instead of `pip` directly in `Makefile` to ensure correct installation of `pip` is used
- Upgrade `pip` in CI to eliminate "newer pip available" message
- Uniquely name test case that was a duplicate name (likely an earlier copy-paste error)